### PR TITLE
first mate

### DIFF
--- a/proxima/code/modules/factions/command/command.dm
+++ b/proxima/code/modules/factions/command/command.dm
@@ -1,0 +1,5 @@
+/datum/job/captain
+	title = "Captain"
+
+/datum/job/hop
+	title = "First Mate"


### PR DESCRIPTION
Переименовываем Первого офицера в Старпома, потому что почему нет. Также дает ему (примерно 10 коммитов назад) титул адъютанта потому что почему нет
